### PR TITLE
fixing import option bug (removal of end of line upon reading saved o…

### DIFF
--- a/i19-gui/chemical_crystallography_gui.py
+++ b/i19-gui/chemical_crystallography_gui.py
@@ -3925,7 +3925,7 @@ class UIXia2Options:
         try:
             with open(saved_options_path_txt) as optionsInput:
                 for line in optionsInput:
-                    line="".join(line.split('\n'))
+                    line = "".join(line.split("\n"))
                     line_split = line.split(" ")
                     if line_split[0] == "I":
                         if int(line_split[1]) == 1:

--- a/i19-gui/chemical_crystallography_gui.py
+++ b/i19-gui/chemical_crystallography_gui.py
@@ -3925,6 +3925,7 @@ class UIXia2Options:
         try:
             with open(saved_options_path_txt) as optionsInput:
                 for line in optionsInput:
+                    line="".join(line.split('\n'))
                     line_split = line.split(" ")
                     if line_split[0] == "I":
                         if int(line_split[1]) == 1:


### PR DESCRIPTION
added single line to fix end of line error upon importing previous xia options. 
line="".join(line.split('\n'))
~3928